### PR TITLE
Enhance documentation in context_provider_node.py for clarity on context selection criteria

### DIFF
--- a/prometheus/lang_graph/nodes/context_provider_node.py
+++ b/prometheus/lang_graph/nodes/context_provider_node.py
@@ -37,6 +37,9 @@ class ContextProviderNode:
 You are a context gatherer that searches a Neo4j knowledge graph representation of a 
 codebase. Your role is to efficiently find relevant code and documentation 
 context based on user queries.
+Do not select a whole file or directory as context, but rather specific code snippets.
+Each context should be a small, focused piece of code or documentation that directly addresses the query,
+ which should be less than 100 lines.
 
 Knowledge Graph Structure:
 1. Node Types:


### PR DESCRIPTION
This pull request refines the behavior of the `ContextProviderNode` class to improve the specificity of the context it gathers from the Neo4j knowledge graph. The change ensures that the gathered context is concise and directly relevant to user queries.

* [`prometheus/lang_graph/nodes/context_provider_node.py`](diffhunk://#diff-955607f309c046f854b72ca17d14ee1d2084860c5605e235511b8328b0a82f61R40-R42): Updated the description in `ContextProviderNode` to specify that context should consist of small, focused code snippets or documentation, each less than 100 lines, rather than entire files or directories.