### PR TITLE
debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN pip install --upgrade pip \
     && pip install hatchling \
     && pip install .[test]
 
-EXPOSE 9001
+EXPOSE 9002
 
-CMD ["uvicorn", "prometheus.app.main:app", "--host", "0.0.0.0", "--port", "9001"]
+CMD ["uvicorn", "prometheus.app.main:app", "--host", "0.0.0.0", "--port", "9002"]

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Prometheus can be connected to other services for extended functionality:
       ```
 
 4. Access Prometheus:
-    - Service: [http://localhost:9001](http://localhost:9001)
-    - OpenAPI Docs: [http://localhost:9001/docs](http://localhost:9001/docs)
+    - Service: [http://localhost:9002](http://localhost:9002)
+    - OpenAPI Docs: [http://localhost:9002/docs](http://localhost:9002/docs)
 
 ---
 
@@ -180,7 +180,7 @@ Set the following variables in your `.env` file:
 5. Start dev server:
 
    ```bash
-   uvicorn prometheus.app.main:app --host 0.0.0.0 --port 9001
+   uvicorn prometheus.app.main:app --host 0.0.0.0 --port 9002
    ```
 
 ---

--- a/docker-compose.win_mac.yml
+++ b/docker-compose.win_mac.yml
@@ -31,7 +31,7 @@ services:
     build: .
     container_name: prometheus
     ports:
-      - "9001:9001"
+      - "9002:9002"
     environment:
       - PROMETHEUS_LOGGING_LEVEL=${PROMETHEUS_LOGGING_LEVEL}
       - PROMETHEUS_NEO4J_URI=${PROMETHEUS_NEO4J_URI}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     networks:
       - prometheus_network
     ports:
-      - "9001:9001"
+      - "9002:9002"
     environment:
       - PROMETHEUS_LOGGING_LEVEL=${PROMETHEUS_LOGGING_LEVEL}
       - PROMETHEUS_NEO4J_URI=${PROMETHEUS_NEO4J_URI}


### PR DESCRIPTION
This pull request introduces updates to the port configuration for the Prometheus service and enhances the container networking setup in the Docker Compose files. The key changes include switching the default port from 9001 to 9002 across various files and adding a dedicated bridge network for container communication.

### Port Configuration Updates:
* Changed the exposed port for the Prometheus service from `9001` to `9002` in the `Dockerfile` and `docker-compose` files. This includes both the internal and external port mappings. (`Dockerfile`: [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L29-R31) `docker-compose.win_mac.yml`: [[2]](diffhunk://#diff-6cbb8d1e2560e17f87d3e842795d9d3c7c0af68434e7a64da008ce1441c740fbL34-R34) `docker-compose.yml`: [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R52-R55)
* Updated references to the Prometheus service URL and OpenAPI documentation in the `README.md` to reflect the new port `9002`. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L183-R183)

### Networking Enhancements:
* Added a dedicated bridge network (`prometheus_network`) in the `docker-compose.yml` file to improve inter-service communication. This network is now used by the `neo4j`, `postgres`, and `prometheus` services. (`docker-compose.yml`: [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R10) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R33-R34) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R52-R55)